### PR TITLE
added callback for closing payment window

### DIFF
--- a/php/payment.php
+++ b/php/payment.php
@@ -102,6 +102,9 @@
                         bKash.execute().onError();
                     }
                 });
+            },
+            onClose: function() {
+                alert('closed')
             }
         });
         


### PR DESCRIPTION
Many developers including me faced this issue when we used the example code from this repo there was an error showing in the console when the user is closing the payment window. added the missing callback.